### PR TITLE
Add Bash shell script version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,21 @@
 
 Display a minimal maxim by The Minimalists after each git commit.
 
-Created under a Python 3.4 environment.
-
 ## Setup
 
-You will need to install some Python modules:
+To use the Python version (created in a Python 3.4 environment)
+you will need to install some modules:
 
     pip install BeautifulSoup4 requests
 
 ## Install
 
-Move the script into the hooks directory of the desired repo:
+Move the script into the hooks directory of the desired repo
+and re-initialise:
 
     mv post-commit.py /path/to/repo/.git/hooks/post-commit
+    cd /path/to/repo/
+    git init
 
 Note: There is no file extension when planted into the hooks directory.
 It is just "post-commit".
@@ -30,6 +32,10 @@ Set a global store of all the Git hooks like so:
 To update existing repos, re-initialise:
 
     git init
+
+The example command line instructions reference the Python script.
+To use the Bash shell script instead, swap out
+**post-commit.py** for **post-commit.sh**.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ you will need to install some modules:
 
     pip install BeautifulSoup4 requests
 
+To use the Bash shell script version `wget` needs to be installed.
+If you don't know if `wget` exists on the machine check for it with:
+
+    which wget
+
+If the path to `wget` does not show, it's not installed.
+
 ## Install
 
 Move the script into the hooks directory of the desired repo

--- a/post-commit.sh
+++ b/post-commit.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+html=$(wget -qO- http://minimalmaxims.com/)
+quote_regex='<span class="quotable-quote"><p>([a-zA-Z0-9 ;’,‘?:\.—\-]+)<\/p>'
+author_regex='<cite class="quoteable-author">([a-zA-Z0-9— ;\.\-]+)<\/cite>'
+
+if [[ $html =~ $quote_regex ]]; then
+    quote=${BASH_REMATCH[1]}
+else
+    echo $html
+fi
+
+if [[ $html =~ $author_regex ]]; then
+    author=${BASH_REMATCH[1]}
+fi
+
+echo
+echo $quote
+echo
+echo "     $author"
+echo

--- a/post-commit.sh
+++ b/post-commit.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+wget_exists=$(which wget > /dev/null; echo $?)
+
+if [[ $wget_exists == 1 ]]; then
+    exit
+fi
+
 html=$(wget -qO- http://minimalmaxims.com/)
 quote_regex='<span class="quotable-quote"><p>([a-zA-Z0-9 ;’,‘?:\.—\-]+)<\/p>'
 author_regex='<cite class="quoteable-author">([a-zA-Z0-9— ;\.\-]+)<\/cite>'

--- a/post-commit.sh
+++ b/post-commit.sh
@@ -15,7 +15,7 @@ if [[ $html =~ $author_regex ]]; then
 fi
 
 echo
-echo $quote
+echo $quote | fold -w 70 -s
 echo
 echo "     $author"
 echo

--- a/post-commit.sh
+++ b/post-commit.sh
@@ -14,8 +14,10 @@ if [[ $html =~ $author_regex ]]; then
     author=${BASH_REMATCH[1]}
 fi
 
-echo
-echo $quote | fold -w 70 -s
-echo
-echo "     $author"
-echo
+if [[ ! -z $quote && ! -z $author ]]; then
+    echo
+    echo $quote | fold -w 70 -s
+    echo
+    echo "     $author"
+    echo
+fi


### PR DESCRIPTION
Creating the Bash shell script version is an exercise is making it more palatable for those who don't want to fool around with the Python version if there isn't a need to.